### PR TITLE
Migrate to Jackson 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <java.version>17</java.version>
 
-        <json-schema-validator.version>2.0.1</json-schema-validator.version>
+        <json-schema-validator.version>3.0.0</json-schema-validator.version>
 
         <spring-boot-config-json-schema-starter.version>1.0.9</spring-boot-config-json-schema-starter.version>
 
@@ -57,15 +57,19 @@
         </dependency>
         <!-- Jackson for YAML and JSON -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jackson</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
         </dependency>
         <!-- JSON Schema Validator -->

--- a/src/main/java/org/alexmond/yaml/validator/output/FilesOutput.java
+++ b/src/main/java/org/alexmond/yaml/validator/output/FilesOutput.java
@@ -4,14 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonRootName;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.networknt.schema.output.OutputUnit;
-import lombok.Builder;
 import lombok.Data;
 
 import org.springframework.boot.ansi.AnsiColor;
 import org.springframework.boot.ansi.AnsiOutput;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 import java.util.Map;
 
@@ -112,9 +111,9 @@ public class FilesOutput {
      * @throws RuntimeException if JSON conversion fails
      */
     public String toJsonString() {
-        ObjectMapper objectMapper = new ObjectMapper();
+        JsonMapper jsonMapper = JsonMapper.builder().build();
         try {
-            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+            return jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
         } catch (Exception e) {
             throw new RuntimeException("Error converting to JSON", e);
         }
@@ -127,9 +126,9 @@ public class FilesOutput {
      * @throws RuntimeException if YAML conversion fails
      */
     public String toYamlString() {
-        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+        YAMLMapper yamlMapper = YAMLMapper.builder().build();
         try {
-            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+            return yamlMapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
         } catch (Exception e) {
             throw new RuntimeException("Error converting to YAML", e);
         }

--- a/src/main/java/org/alexmond/yaml/validator/output/FilesOutputToJunit.java
+++ b/src/main/java/org/alexmond/yaml/validator/output/FilesOutputToJunit.java
@@ -1,19 +1,16 @@
 package org.alexmond.yaml.validator.output;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import com.networknt.schema.output.OutputUnit;
 import lombok.RequiredArgsConstructor;
 import org.alexmond.yaml.validator.output.junit.Failure;
 import org.alexmond.yaml.validator.output.junit.Testcase;
 import org.alexmond.yaml.validator.output.junit.Testsuite;
 import org.alexmond.yaml.validator.output.junit.Testsuites;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlWriteFeature;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
 
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamWriter;
-import java.io.StringWriter;
 import java.util.Map;
 
 /**
@@ -43,15 +40,15 @@ public class FilesOutputToJunit {
                 .build();
 
         try {
-            XmlMapper xmlMapper = new XmlMapper();
-            xmlMapper.enable(SerializationFeature.INDENT_OUTPUT);
-            xmlMapper.enable(ToXmlGenerator.Feature.WRITE_XML_DECLARATION);
+            XmlMapper xmlMapper = XmlMapper.builder()
+                    .enable(SerializationFeature.INDENT_OUTPUT)
+                    .enable(XmlWriteFeature.WRITE_XML_DECLARATION)
+                .build();
             return xmlMapper.writeValueAsString(testsuites);
         } catch (Exception e) {
             throw new RuntimeException("Error converting to JUnit XML", e);
         }
     }
-
     /**
      * Builds a test suite from the validation results.
      * Creates individual test cases for each validated file and includes failure details

--- a/src/main/java/org/alexmond/yaml/validator/output/FilesOutputToSarif.java
+++ b/src/main/java/org/alexmond/yaml/validator/output/FilesOutputToSarif.java
@@ -1,10 +1,11 @@
 package org.alexmond.yaml.validator.output;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.networknt.schema.output.OutputUnit;
 import lombok.RequiredArgsConstructor;
 import org.alexmond.yaml.validator.output.sarif.*;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -34,9 +35,10 @@ public class FilesOutputToSarif {
                 .build();
 
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-            return objectMapper.writeValueAsString(sarifReport);
+            JsonMapper jsonMapper = JsonMapper.builder()
+                    .configure(SerializationFeature.INDENT_OUTPUT, true)
+                    .build();
+            return jsonMapper.writeValueAsString(sarifReport);
         } catch (Exception e) {
             throw new RuntimeException("Error converting to SARIF JSON", e);
         }

--- a/src/main/java/org/alexmond/yaml/validator/output/junit/Failure.java
+++ b/src/main/java/org/alexmond/yaml/validator/output/junit/Failure.java
@@ -1,9 +1,10 @@
 package org.alexmond.yaml.validator.output.junit;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+
 import lombok.Builder;
 import lombok.Data;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
 
 
 /**

--- a/src/main/java/org/alexmond/yaml/validator/output/junit/Testcase.java
+++ b/src/main/java/org/alexmond/yaml/validator/output/junit/Testcase.java
@@ -1,9 +1,9 @@
 package org.alexmond.yaml.validator.output.junit;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Data;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 
 /**
@@ -12,7 +12,6 @@ import lombok.Data;
  * This class is used for serialization of test results into XML format
  * compatible with JUnit report specifications.
  */
-@JacksonXmlRootElement(localName = "testcase")
 @Data
 @Builder
 public class Testcase {
@@ -42,6 +41,7 @@ public class Testcase {
      * The failure details if the test case failed.
      * Null if the test case passed.
      */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JacksonXmlProperty(localName = "failure")
     private Failure failure;
 }

--- a/src/main/java/org/alexmond/yaml/validator/output/junit/Testsuite.java
+++ b/src/main/java/org/alexmond/yaml/validator/output/junit/Testsuite.java
@@ -1,8 +1,9 @@
 package org.alexmond.yaml.validator.output.junit;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.Builder;
 import lombok.Data;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 import java.util.List;
 
@@ -65,6 +66,7 @@ public class Testsuite {
     /**
      * List of individual test cases contained in this suite
      */
+    @JacksonXmlElementWrapper(useWrapping = false)
     @JacksonXmlProperty(localName = "testcase")
     @Builder.Default
     private List<Testcase> testcases = new java.util.ArrayList<>();

--- a/src/main/java/org/alexmond/yaml/validator/output/junit/Testsuites.java
+++ b/src/main/java/org/alexmond/yaml/validator/output/junit/Testsuites.java
@@ -1,9 +1,9 @@
 package org.alexmond.yaml.validator.output.junit;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import lombok.Builder;
 import lombok.Data;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * JUnit XML model representing a collection of test suites.

--- a/src/test/java/org/alexmond/yaml/validator/YamlSchemaValidatorRunnerTest.java
+++ b/src/test/java/org/alexmond/yaml/validator/YamlSchemaValidatorRunnerTest.java
@@ -6,6 +6,7 @@ import com.networknt.schema.output.OutputUnit;
 import org.alexmond.yaml.validator.config.ReportType;
 import org.alexmond.yaml.validator.config.YamlSchemaValidatorConfig;
 import org.alexmond.yaml.validator.output.FilesOutput;
+import org.alexmond.yaml.validator.util.XmlCompareUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -223,7 +224,7 @@ class YamlSchemaValidatorRunnerTest {
         }else{
             assertFalse(result.isValid(), "Expected result to be not valid for the provided file");
         }
-        assertTrue(compareFiles(reportFile,reportsDir + expectedReport), "Reports should match");
+        assertTrue(XmlCompareUtil.compareFiles(reportFile,reportsDir + expectedReport), "Reports should match");
 
     }
 
@@ -260,35 +261,10 @@ class YamlSchemaValidatorRunnerTest {
         }else{
             assertFalse(result.isValid(), "Expected result to be not valid for the provided file");
         }
-        assertTrue(compareFiles(reportFile,reportsDir + expectedReport), "Reports should match");
+        assertTrue(XmlCompareUtil.compareFiles(reportFile,reportsDir + expectedReport), "Reports should match");
 
     }
 
-    /**
-     * Compares two files byte by byte to check if they are identical.
-     *
-     * @param path1 Path to the first file
-     * @param path2 Path to the second file
-     * @return true if files are identical, false otherwise or if files cannot be read
-     */
-
-    public boolean compareFiles(String path1, String path2) {
-        try {
-            String content1 = new String(Files.readAllBytes(Paths.get(path1)));
-            String content2 = new String(Files.readAllBytes(Paths.get(path2)));
-
-            // Remove timestamps before comparison in sarif files
-            content1 = content1.replaceAll("\"startTimeUtc\"\\s*:\\s*\"[^\"]*\"", "\"startTimeUtc\":\"\"");
-            content1 = content1.replaceAll("\"endTimeUtc\"\\s*:\\s*\"[^\"]*\"", "\"endTimeUtc\":\"\"");
-            content2 = content2.replaceAll("\"startTimeUtc\"\\s*:\\s*\"[^\"]*\"", "\"startTimeUtc\":\"\"");
-            content2 = content2.replaceAll("\"endTimeUtc\"\\s*:\\s*\"[^\"]*\"", "\"endTimeUtc\":\"\"");
-
-            return content1.equals(content2);
-        } catch (IOException e) {
-            // Handles cases where files don't exist or can't be read
-            return false;
-        }
-    }
 
     /**
      * Test to verify that Validate() method processes invalid YAML files and returns invalid output.

--- a/src/test/java/org/alexmond/yaml/validator/output/FilesOutputToJunitTest.java
+++ b/src/test/java/org/alexmond/yaml/validator/output/FilesOutputToJunitTest.java
@@ -1,6 +1,8 @@
 package org.alexmond.yaml.validator.output;
 
 import com.networknt.schema.output.OutputUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.yaml.validator.util.XmlCompareUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -18,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Test class for JUnit XML format output generation.
  * Tests the conversion of validation results to JUnit XML format.
  */
+@Slf4j
 class FilesOutputToJunitTest {
 
     @Test
@@ -90,7 +93,7 @@ class FilesOutputToJunitTest {
         // Assert
         try {
             Files.writeString(Path.of("test1junit.xml"), junitString);
-            assertTrue(compareFileToString(junitString, "src/test/resources/testreport/test1junit.xml"));
+            assertTrue(XmlCompareUtil.compareFileToString(junitString, "src/test/resources/testreport/test1junit.xml"));
         } catch (IOException e) {
             throw new RuntimeException("Failed to write JUnit XML file", e);
         }
@@ -302,19 +305,4 @@ class FilesOutputToJunitTest {
                 .contains("Second error");
     }
 
-    /**
-     * Compares JUnit XML output with expected file content.
-     *
-     * @param junitString Generated JUnit XML string
-     * @param fileName    Path to expected JUnit XML file
-     * @return true if content matches, false otherwise
-     */
-    private boolean compareFileToString(String junitString, String fileName) {
-        try {
-            String fileContent = Files.readString(Path.of(fileName));
-            return junitString.trim().equals(fileContent.trim());
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to read JUnit XML file", e);
-        }
-    }
 }

--- a/src/test/java/org/alexmond/yaml/validator/util/XmlCompareUtil.java
+++ b/src/test/java/org/alexmond/yaml/validator/util/XmlCompareUtil.java
@@ -1,0 +1,138 @@
+package org.alexmond.yaml.validator.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Utility class for comparing XML, JSON, and SARIF files.
+ * Handles Jackson 3 attribute/property ordering differences.
+ */
+public class XmlCompareUtil {
+
+    /**
+     * Compares two files with normalization for XML/JSON attribute ordering.
+     *
+     * @param path1 Path to the first file
+     * @param path2 Path to the second file
+     * @return true if files are identical after normalization, false otherwise
+     */
+    public static boolean compareFiles(String path1, String path2) {
+        try {
+            String content1 = Files.readString(Paths.get(path1));
+            String content2 = Files.readString(Paths.get(path2));
+
+            // Remove timestamps before comparison in sarif files
+            content1 = content1.replaceAll("\"startTimeUtc\"\\s*:\\s*\"[^\"]*\"", "\"startTimeUtc\":\"\"");
+            content1 = content1.replaceAll("\"endTimeUtc\"\\s*:\\s*\"[^\"]*\"", "\"endTimeUtc\":\"\"");
+            content2 = content2.replaceAll("\"startTimeUtc\"\\s*:\\s*\"[^\"]*\"", "\"startTimeUtc\":\"\"");
+            content2 = content2.replaceAll("\"endTimeUtc\"\\s*:\\s*\"[^\"]*\"", "\"endTimeUtc\":\"\"");
+
+            // Normalize XML/JSON attribute ordering for Jackson 3 compatibility
+            if (path1.endsWith(".xml") || path1.endsWith(".json") || path1.endsWith(".sarif")) {
+                content1 = normalizeStructuredContent(content1);
+                content2 = normalizeStructuredContent(content2);
+            }
+
+            boolean matches = content1.equals(content2);
+            if (!matches) {
+                System.out.println("Files differ: " + path1 + " vs " + path2);
+                String[] lines1 = content1.split("\n");
+                String[] lines2 = content2.split("\n");
+                int maxLines = Math.max(lines1.length, lines2.length);
+                for (int i = 0; i < Math.min(10, maxLines); i++) {
+                    String line1 = i < lines1.length ? lines1[i] : "";
+                    String line2 = i < lines2.length ? lines2[i] : "";
+                    if (!line1.equals(line2)) {
+                        System.out.println("Line " + (i + 1) + " differs:");
+                        System.out.println("  Actual:   " + line1);
+                        System.out.println("  Expected: " + line2);
+                    }
+                }
+            }
+            return matches;
+        } catch (IOException e) {
+            System.err.println("Error comparing files: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Compares file content with a string.
+     *
+     * @param fileString The string to compare
+     * @param fileName   Path to the file
+     * @return true if content matches after normalization, false otherwise
+     */
+    public static boolean compareFileToString(String fileString, String fileName) {
+        try {
+            String fileContent = Files.readString(Path.of(fileName));
+            String[] actualLines = fileString.trim().split("\n");
+            String[] expectedLines = fileContent.trim().split("\n");
+
+            boolean matches = true;
+            int maxLines = Math.max(actualLines.length, expectedLines.length);
+
+            for (int i = 0; i < maxLines; i++) {
+                String actualLine = i < actualLines.length ? actualLines[i] : "";
+                String expectedLine = i < expectedLines.length ? expectedLines[i] : "";
+
+                if (!normalizeXmlLine(actualLine).equals(normalizeXmlLine(expectedLine))) {
+                    matches = false;
+                    System.out.println("Line " + (i + 1) + " differs:");
+                    System.out.println("  Expected: " + expectedLine);
+                    System.out.println("  Actual:   " + actualLine);
+                }
+            }
+
+            return matches;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read file: " + fileName, e);
+        }
+    }
+
+    /**
+     * Normalizes XML attributes and JSON properties to handle different ordering from Jackson 3.
+     */
+    private static String normalizeStructuredContent(String content) {
+        String[] lines = content.split("\n");
+        StringBuilder normalized = new StringBuilder();
+
+        for (String line : lines) {
+            normalized.append(normalizeXmlLine(line.trim())).append("\n");
+        }
+
+        return normalized.toString();
+    }
+
+    /**
+     * Normalizes XML line by sorting attributes to handle different serialization orders.
+     */
+    public static String normalizeXmlLine(String line) {
+        String trimmed = line.trim();
+
+        // Check if line contains XML element with attributes
+        if (!trimmed.startsWith("<") || !trimmed.contains("=")) {
+            return trimmed;
+        }
+
+        // Extract tag name
+        int firstSpace = trimmed.indexOf(' ');
+        int firstClose = trimmed.indexOf('>');
+
+        if (firstSpace == -1 || firstClose == -1 || firstSpace > firstClose) {
+            return trimmed;
+        }
+
+        String tagStart = trimmed.substring(0, firstSpace);
+        String tagEnd = trimmed.substring(firstClose);
+        String attributes = trimmed.substring(firstSpace + 1, firstClose).trim();
+
+        // Sort attributes alphabetically
+        String[] attrs = attributes.split("\\s+(?=\\w+=)");
+        java.util.Arrays.sort(attrs);
+
+        return tagStart + " " + String.join(" ", attrs) + tagEnd;
+    }
+}

--- a/src/test/resources/testreport/invalidyaml.sarif
+++ b/src/test/resources/testreport/invalidyaml.sarif
@@ -1,36 +1,14 @@
 {
-  "version" : "2.1.0",
   "$schema" : "https://json.schemastore.org/sarif-2.1.0.json",
   "runs" : [ {
-    "tool" : {
-      "driver" : {
-        "name" : "YAML Schema Validator",
-        "version" : "1.0.0",
-        "informationUri" : "https://github.com/alexmond/yj-schema-validator",
-        "semanticVersion" : "1.0.0",
-        "rules" : [ {
-          "id" : "schema-validation",
-          "shortDescription" : {
-            "text" : "Schema validation error"
-          },
-          "fullDescription" : {
-            "text" : "The file does not conform to the specified JSON/YAML schema"
-          },
-          "help" : {
-            "text" : "Ensure that the file content matches the schema definition"
-          },
-          "defaultConfiguration" : {
-            "level" : "error"
-          }
-        } ]
-      }
-    },
+    "invocations" : [ {
+      "endTimeUtc" : "2026-02-21T08:47:06.439866Z",
+      "executionSuccessful" : false,
+      "exitCode" : 1,
+      "startTimeUtc" : "2026-02-21T08:47:06.439142Z"
+    } ],
     "results" : [ {
-      "ruleId" : "schema-validation",
       "level" : "error",
-      "message" : {
-        "text" : "At path '/sample/boolean-sample': integer found, boolean expected"
-      },
       "locations" : [ {
         "physicalLocation" : {
           "artifactLocation" : {
@@ -42,13 +20,35 @@
             }
           }
         }
-      } ]
+      } ],
+      "message" : {
+        "text" : "At path '/sample/boolean-sample': integer found, boolean expected"
+      },
+      "ruleId" : "schema-validation"
     } ],
-    "invocations" : [ {
-      "executionSuccessful" : false,
-      "startTimeUtc" : "2025-12-14T05:32:56.122575Z",
-      "endTimeUtc" : "2025-12-14T05:32:56.132260Z",
-      "exitCode" : 1
-    } ]
-  } ]
+    "tool" : {
+      "driver" : {
+        "informationUri" : "https://github.com/alexmond/yj-schema-validator",
+        "name" : "YAML Schema Validator",
+        "rules" : [ {
+          "defaultConfiguration" : {
+            "level" : "error"
+          },
+          "fullDescription" : {
+            "text" : "The file does not conform to the specified JSON/YAML schema"
+          },
+          "help" : {
+            "text" : "Ensure that the file content matches the schema definition"
+          },
+          "id" : "schema-validation",
+          "shortDescription" : {
+            "text" : "Schema validation error"
+          }
+        } ],
+        "semanticVersion" : "1.0.0",
+        "version" : "1.0.0"
+      }
+    }
+  } ],
+  "version" : "2.1.0"
 }

--- a/src/test/resources/testreport/invalidyaml.xml
+++ b/src/test/resources/testreport/invalidyaml.xml
@@ -1,10 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<testsuites name="SchemaValidationSuite" tests="1" failures="1" errors="0" skipped="0">
-  <testsuite name="SchemaValidationSuite" file="src/test/resources" time="0.0" tests="1" failures="1" errors="0" skipped="0">
-    <testcase>
-      <testcase classname="files" name="src/test/resources/testdata/invalid.yaml" time="0.0">
-        <failure message="Type Mismatch at /sample/boolean-sample">integer found, boolean expected</failure>
-      </testcase>
+<testsuites errors="0" failures="1" name="SchemaValidationSuite" skipped="0" tests="1">
+  <testsuite errors="0" failures="1" file="src/test/resources" name="SchemaValidationSuite" skipped="0" tests="1" time="0.0">
+    <testcase classname="files" name="src/test/resources/testdata/invalid.yaml" time="0.0">
+      <failure message="Type Mismatch at /sample/boolean-sample">integer found, boolean expected</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/src/test/resources/testreport/multi3invalidyaml.sarif
+++ b/src/test/resources/testreport/multi3invalidyaml.sarif
@@ -1,36 +1,14 @@
 {
-  "version" : "2.1.0",
   "$schema" : "https://json.schemastore.org/sarif-2.1.0.json",
   "runs" : [ {
-    "tool" : {
-      "driver" : {
-        "name" : "YAML Schema Validator",
-        "version" : "1.0.0",
-        "informationUri" : "https://github.com/alexmond/yj-schema-validator",
-        "semanticVersion" : "1.0.0",
-        "rules" : [ {
-          "id" : "schema-validation",
-          "shortDescription" : {
-            "text" : "Schema validation error"
-          },
-          "fullDescription" : {
-            "text" : "The file does not conform to the specified JSON/YAML schema"
-          },
-          "help" : {
-            "text" : "Ensure that the file content matches the schema definition"
-          },
-          "defaultConfiguration" : {
-            "level" : "error"
-          }
-        } ]
-      }
-    },
+    "invocations" : [ {
+      "endTimeUtc" : "2026-02-21T08:47:06.377705Z",
+      "executionSuccessful" : false,
+      "exitCode" : 1,
+      "startTimeUtc" : "2026-02-21T08:47:06.372855Z"
+    } ],
     "results" : [ {
-      "ruleId" : "schema-validation",
       "level" : "error",
-      "message" : {
-        "text" : "No schema found in YAML file or provided as parameter"
-      },
       "locations" : [ {
         "physicalLocation" : {
           "artifactLocation" : {
@@ -38,13 +16,35 @@
           },
           "region" : { }
         }
-      } ]
+      } ],
+      "message" : {
+        "text" : "No schema found in YAML file or provided as parameter"
+      },
+      "ruleId" : "schema-validation"
     } ],
-    "invocations" : [ {
-      "executionSuccessful" : false,
-      "startTimeUtc" : "2025-12-14T05:37:35.277186Z",
-      "endTimeUtc" : "2025-12-14T05:37:35.281629Z",
-      "exitCode" : 1
-    } ]
-  } ]
+    "tool" : {
+      "driver" : {
+        "informationUri" : "https://github.com/alexmond/yj-schema-validator",
+        "name" : "YAML Schema Validator",
+        "rules" : [ {
+          "defaultConfiguration" : {
+            "level" : "error"
+          },
+          "fullDescription" : {
+            "text" : "The file does not conform to the specified JSON/YAML schema"
+          },
+          "help" : {
+            "text" : "Ensure that the file content matches the schema definition"
+          },
+          "id" : "schema-validation",
+          "shortDescription" : {
+            "text" : "Schema validation error"
+          }
+        } ],
+        "semanticVersion" : "1.0.0",
+        "version" : "1.0.0"
+      }
+    }
+  } ],
+  "version" : "2.1.0"
 }

--- a/src/test/resources/testreport/multi3invalidyaml.xml
+++ b/src/test/resources/testreport/multi3invalidyaml.xml
@@ -1,16 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<testsuites name="SchemaValidationSuite" tests="3" failures="1" errors="0" skipped="0">
-  <testsuite name="SchemaValidationSuite" file="src/test/resources" time="0.0" tests="3" failures="1" errors="0" skipped="0">
-    <testcase>
-      <testcase classname="files" name="src/test/resources/testdata/multi3invalid.yaml-1" time="0.0">
-        <failure/>
-      </testcase>
-      <testcase classname="files" name="src/test/resources/testdata/multi3invalid.yaml-2" time="0.0">
-        <failure message="No Schema Error">No schema found in YAML file or provided as parameter</failure>
-      </testcase>
-      <testcase classname="files" name="src/test/resources/testdata/multi3invalid.yaml-3" time="0.0">
-        <failure/>
-      </testcase>
+<testsuites errors="0" failures="1" name="SchemaValidationSuite" skipped="0" tests="3">
+  <testsuite errors="0" failures="1" file="src/test/resources" name="SchemaValidationSuite" skipped="0" tests="3" time="0.0">
+    <testcase classname="files" name="src/test/resources/testdata/multi3invalid.yaml-1" time="0.0"/>
+    <testcase classname="files" name="src/test/resources/testdata/multi3invalid.yaml-2" time="0.0">
+      <failure message="No Schema Error">No schema found in YAML file or provided as parameter</failure>
     </testcase>
+    <testcase classname="files" name="src/test/resources/testdata/multi3invalid.yaml-3" time="0.0"/>
   </testsuite>
 </testsuites>

--- a/src/test/resources/testreport/test1junit.xml
+++ b/src/test/resources/testreport/test1junit.xml
@@ -1,10 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<testsuites name="SchemaValidationSuite" tests="1" failures="1" errors="0" skipped="0">
-  <testsuite name="SchemaValidationSuite" file="src/test/resources" time="0.0" tests="1" failures="1" errors="0" skipped="0">
-    <testcase>
-      <testcase classname="files" name="invalid.yaml" time="0.0">
-        <failure message="Type Mismatch at $.sample.boolean-sample">integer found, boolean expected</failure>
-      </testcase>
+<testsuites errors="0" failures="1" name="SchemaValidationSuite" skipped="0" tests="1">
+  <testsuite errors="0" failures="1" file="src/test/resources" name="SchemaValidationSuite" skipped="0" tests="1" time="0.0">
+    <testcase classname="files" name="invalid.yaml" time="0.0">
+      <failure message="Type Mismatch at $.sample.boolean-sample">integer found, boolean expected</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/src/test/resources/testreport/validyaml.sarif
+++ b/src/test/resources/testreport/validyaml.sarif
@@ -1,17 +1,20 @@
 {
-  "version" : "2.1.0",
   "$schema" : "https://json.schemastore.org/sarif-2.1.0.json",
   "runs" : [ {
+    "invocations" : [ {
+      "endTimeUtc" : "2026-02-21T08:47:06.287808Z",
+      "executionSuccessful" : true,
+      "exitCode" : 0,
+      "startTimeUtc" : "2026-02-21T08:47:06.276374Z"
+    } ],
+    "results" : [ ],
     "tool" : {
       "driver" : {
-        "name" : "YAML Schema Validator",
-        "version" : "1.0.0",
         "informationUri" : "https://github.com/alexmond/yj-schema-validator",
-        "semanticVersion" : "1.0.0",
+        "name" : "YAML Schema Validator",
         "rules" : [ {
-          "id" : "schema-validation",
-          "shortDescription" : {
-            "text" : "Schema validation error"
+          "defaultConfiguration" : {
+            "level" : "error"
           },
           "fullDescription" : {
             "text" : "The file does not conform to the specified JSON/YAML schema"
@@ -19,18 +22,15 @@
           "help" : {
             "text" : "Ensure that the file content matches the schema definition"
           },
-          "defaultConfiguration" : {
-            "level" : "error"
+          "id" : "schema-validation",
+          "shortDescription" : {
+            "text" : "Schema validation error"
           }
-        } ]
+        } ],
+        "semanticVersion" : "1.0.0",
+        "version" : "1.0.0"
       }
-    },
-    "results" : [ ],
-    "invocations" : [ {
-      "executionSuccessful" : true,
-      "startTimeUtc" : "2025-12-14T05:37:35.192446Z",
-      "endTimeUtc" : "2025-12-14T05:37:35.198920Z",
-      "exitCode" : 0
-    } ]
-  } ]
+    }
+  } ],
+  "version" : "2.1.0"
 }

--- a/src/test/resources/testreport/validyaml.xml
+++ b/src/test/resources/testreport/validyaml.xml
@@ -1,13 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<testsuites name="SchemaValidationSuite" tests="2" failures="0" errors="0" skipped="0">
-  <testsuite name="SchemaValidationSuite" file="src/test/resources" time="0.0" tests="2" failures="0" errors="0" skipped="0">
-    <testcase>
-      <testcase classname="files" name="src/test/resources/testdata/valid.yaml-1" time="0.0">
-        <failure/>
-      </testcase>
-      <testcase classname="files" name="src/test/resources/testdata/valid.yaml-2" time="0.0">
-        <failure/>
-      </testcase>
-    </testcase>
+<testsuites errors="0" failures="0" name="SchemaValidationSuite" skipped="0" tests="2">
+  <testsuite errors="0" failures="0" file="src/test/resources" name="SchemaValidationSuite" skipped="0" tests="2" time="0.0">
+    <testcase classname="files" name="src/test/resources/testdata/valid.yaml-1" time="0.0"/>
+    <testcase classname="files" name="src/test/resources/testdata/valid.yaml-2" time="0.0"/>
   </testsuite>
 </testsuites>


### PR DESCRIPTION
Closes #7

## Summary
Complete migration from Jackson 2.x to Jackson 3.x following the [official migration guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md).

## Changes

### Core Migration
- ✅ Upgraded Jackson dependencies to 3.0+ with new `tools.jackson` package namespace
- ✅ Replaced `ObjectMapper(new YAMLFactory())` with format-specific mappers: `YAMLMapper`, `JsonMapper`, `XmlMapper`
- ✅ Applied builder pattern for all mapper instantiation following Jackson 3 best practices
- ✅ Implemented multi-document YAML parsing using `readValues().readAll()` API

### Bug Fixes
- 🐛 Fixed empty `<failure>` elements appearing in valid JUnit XML testcases by adding `@JsonInclude(JsonInclude.Include.NON_NULL)`
- 🐛 Removed duplicate XML testcase nesting by removing `@JacksonXmlRootElement` annotation
- 🐛 Added `@JacksonXmlElementWrapper(useWrapping = false)` for proper XML list serialization
- 🐛 Updated exception handling from `MarkedYAMLException` to `JacksonYAMLParseException`
- 🐛 Replaced deprecated `asText()` with `textValue()` for JsonNode operations

### Test Improvements
- 🧪 Created `XmlCompareUtil` utility class for attribute-order-independent XML/JSON comparison
- 🧪 Extracted comparison logic to shared utility for better maintainability
- 🧪 Regenerated all expected test output files with Jackson 3 format
- 🧪 Fixed XML attribute ordering differences between Jackson 2 and 3

## Testing
- ✅ All 69 tests passing
- ✅ No breaking changes to public API
- ✅ Build succeeds with only minor deprecation warnings

## Migration Guide Compliance
Followed official Jackson 3 migration guidelines:
- Used format-aligned mappers (requirement #7)
- Applied builder pattern (requirement #6)
- Updated to `tools.jackson` package namespace (requirement #2)
- Handled multi-document YAML with proper Jackson 3 API

🤖 Generated with [Claude Code](https://claude.com/claude-code)