### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,12 @@
     <properties>
         <java.version>17</java.version>
 
-        <json-schema-validator.version>3.0.0</json-schema-validator.version>
+        <json-schema-validator.version>3.0.2</json-schema-validator.version>
 
-        <spring-boot-config-json-schema-starter.version>1.0.9</spring-boot-config-json-schema-starter.version>
+        <spring-boot-config-json-schema-starter.version>3.5.10.1</spring-boot-config-json-schema-starter.version>
 
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-        <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
 
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>


### PR DESCRIPTION
## Summary
- Upgrade `json-schema-validator` 3.0.0 → 3.0.2 (patch)
- Upgrade `spring-boot-config-json-schema-starter` 1.0.9 → 3.5.10.1 (major)
- Upgrade `central-publishing-maven-plugin` 0.9.0 → 0.10.0 (minor)

## Test plan
- [x] `./mvnw clean package` passes (69 tests, 0 failures)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)