### PR TITLE
Complete Jackson 3.x migration in test code

### DIFF
--- a/src/test/java/org/alexmond/yaml/validator/output/FilesOutputToSarifTest.java
+++ b/src/test/java/org/alexmond/yaml/validator/output/FilesOutputToSarifTest.java
@@ -1,7 +1,8 @@
 package org.alexmond.yaml.validator.output;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 import com.networknt.schema.output.OutputUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class FilesOutputToSarifTest {
 
-	private static final ObjectMapper objectMapper = new ObjectMapper();
+	private static final JsonMapper objectMapper = JsonMapper.builder().build();
 
 	@Test
 	@DisplayName("toSarifString: Should generate valid SARIF JSON when all files are valid")
@@ -261,13 +262,8 @@ class FilesOutputToSarifTest {
 		assertThat(sarifString).isNotEmpty();
 
 		// Verify it's valid JSON by parsing it
-		try {
-			JsonNode jsonNode = objectMapper.readTree(sarifString);
-			assertThat(jsonNode).isNotNull();
-		}
-		catch (IOException ex) {
-			throw new AssertionError("Generated SARIF is not valid JSON", ex);
-		}
+		JsonNode jsonNode = objectMapper.readTree(sarifString);
+		assertThat(jsonNode).isNotNull();
 	}
 
 	/**
@@ -300,8 +296,8 @@ class FilesOutputToSarifTest {
 	 */
 	private void removeTimestampFields(JsonNode jsonNode) {
 		if (jsonNode.isObject()) {
-			((com.fasterxml.jackson.databind.node.ObjectNode) jsonNode).remove("startTimeUtc");
-			((com.fasterxml.jackson.databind.node.ObjectNode) jsonNode).remove("endTimeUtc");
+			((ObjectNode) jsonNode).remove("startTimeUtc");
+			((ObjectNode) jsonNode).remove("endTimeUtc");
 		}
 		jsonNode.forEach(this::removeTimestampFields);
 	}

--- a/src/test/java/org/alexmond/yaml/validator/testimpl/MultiYamlParser.java
+++ b/src/test/java/org/alexmond/yaml/validator/testimpl/MultiYamlParser.java
@@ -1,7 +1,7 @@
 package org.alexmond.yaml.validator.testimpl;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.error.YAMLException;
@@ -23,8 +23,9 @@ public class MultiYamlParser {
 
 	private final Yaml yaml = new Yaml(); // Thread-safe; reuse instance
 
-	private final ObjectMapper objectMapper = new ObjectMapper(); // For converting to
-																	// JsonNode
+	private final JsonMapper objectMapper = JsonMapper.builder().build(); // For
+																			// converting
+																			// to JsonNode
 
 	/**
 	 * Parses multi-document YAML content (as a string) into a list of JsonNode documents.

--- a/src/test/java/org/alexmond/yaml/validator/testimpl/PropertiesToJson.java
+++ b/src/test/java/org/alexmond/yaml/validator/testimpl/PropertiesToJson.java
@@ -1,10 +1,10 @@
 package org.alexmond.yaml.validator.testimpl; // Java
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
@@ -24,7 +24,7 @@ public class PropertiesToJson {
 	private static final Pattern INDEX = Pattern.compile("\\[([0-9]+)]");
 
 	public JsonNode toJson(PropertySourcesPropertyResolver resolver, MutablePropertySources sources) {
-		ObjectMapper mapper = new ObjectMapper();
+		JsonMapper mapper = JsonMapper.builder().build();
 		ObjectNode root = mapper.createObjectNode();
 		Collection<String> propertyNames = collectPropertyNames(sources);
 
@@ -49,7 +49,7 @@ public class PropertiesToJson {
 		return names;
 	}
 
-	private void insert(ObjectNode root, String key, JsonNode value, ObjectMapper mapper) {
+	private void insert(ObjectNode root, String key, JsonNode value, JsonMapper mapper) {
 		ObjectNode currentObj = root;
 		ArrayNode currentArr = null;
 		String pendingLeaf = null;
@@ -179,7 +179,7 @@ public class PropertiesToJson {
 		}
 	}
 
-	private ObjectNode ensureObject(ArrayNode array, int index, ObjectMapper mapper) {
+	private ObjectNode ensureObject(ArrayNode array, int index, JsonMapper mapper) {
 		// When index == -1 this method is used only to satisfy flow; return a new object
 		if (index < 0) {
 			return mapper.createObjectNode();
@@ -194,7 +194,7 @@ public class PropertiesToJson {
 		return (ObjectNode) node;
 	}
 
-	private JsonNode coerce(ObjectMapper mapper, String value) {
+	private JsonNode coerce(JsonMapper mapper, String value) {
 		if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
 			return mapper.getNodeFactory().booleanNode(Boolean.parseBoolean(value));
 		}

--- a/src/test/java/org/alexmond/yaml/validator/testimpl/YamlProprtySourceLoaderTest.java
+++ b/src/test/java/org/alexmond/yaml/validator/testimpl/YamlProprtySourceLoaderTest.java
@@ -1,6 +1,6 @@
 package org.alexmond.yaml.validator.testimpl;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;


### PR DESCRIPTION
## Summary
- Replace `com.fasterxml.jackson.databind.*` imports with `tools.jackson.databind.*` in 4 test files
- Replace `new ObjectMapper()` with `JsonMapper.builder().build()` (Jackson 3.x pattern)
- Replace inline FQN casts with proper imports
- Remove unnecessary `IOException` catch around `readTree()` (unchecked in Jackson 3.x)

## Test plan
- [x] `./mvnw clean package` passes (69 tests, 0 failures)
- [x] Zero `com.fasterxml.jackson.databind` references remain in source

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)