### PR TITLE
Add GraalVM native image support for multi-platform releases

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -1,0 +1,88 @@
+name: Build Native Images
+
+on:
+  push:
+    tags:
+      - '[0-9]*'
+
+jobs:
+  build-native:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: yj-schema-validator-linux-amd64
+            extension: ''
+          - os: ubuntu-24.04-arm
+            artifact: yj-schema-validator-linux-arm64
+            extension: ''
+          - os: macos-13
+            artifact: yj-schema-validator-macos-amd64
+            extension: ''
+          - os: macos-latest
+            artifact: yj-schema-validator-macos-arm64
+            extension: ''
+          - os: windows-latest
+            artifact: yj-schema-validator-windows-amd64
+            extension: '.exe'
+
+    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.artifact }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '17'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Visual Studio shell (Windows only)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build native image
+        run: ./mvnw -B -Pnative native:compile -DskipTests --no-transfer-progress
+
+      - name: Rename artifact
+        shell: bash
+        run: mv target/yj-schema-validator${{ matrix.extension }} target/${{ matrix.artifact }}${{ matrix.extension }}
+
+      - name: Smoke test
+        shell: bash
+        run: |
+          ./target/${{ matrix.artifact }}${{ matrix.extension }} --help
+          ./target/${{ matrix.artifact }}${{ matrix.extension }} --schema=src/test/resources/testdata/sample-schema.json src/test/resources/testdata/valid.yaml
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: target/${{ matrix.artifact }}${{ matrix.extension }}
+
+  publish-release:
+    needs: build-native
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            artifacts/yj-schema-validator-linux-amd64/*
+            artifacts/yj-schema-validator-linux-arm64/*
+            artifacts/yj-schema-validator-macos-amd64/*
+            artifacts/yj-schema-validator-macos-arm64/*
+            artifacts/yj-schema-validator-windows-amd64/*

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,24 @@
     </build>
     <profiles>
         <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <configuration>
+                            <imageName>yj-schema-validator</imageName>
+                            <buildArgs>
+                                <buildArg>--no-fallback</buildArg>
+                                <buildArg>-H:+ReportExceptionStackTraces</buildArg>
+                            </buildArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>release</id>
             <build>
                 <plugins>

--- a/src/main/java/org/alexmond/yaml/validator/NativeImageHints.java
+++ b/src/main/java/org/alexmond/yaml/validator/NativeImageHints.java
@@ -1,0 +1,127 @@
+package org.alexmond.yaml.validator;
+
+import org.alexmond.yaml.validator.config.ReportType;
+import org.alexmond.yaml.validator.config.YamlSchemaValidatorConfig;
+import org.alexmond.yaml.validator.output.FilesOutput;
+import org.alexmond.yaml.validator.output.FilesOutputToJunit;
+import org.alexmond.yaml.validator.output.FilesOutputToSarif;
+import org.alexmond.yaml.validator.output.junit.Failure;
+import org.alexmond.yaml.validator.output.junit.Testcase;
+import org.alexmond.yaml.validator.output.junit.Testsuite;
+import org.alexmond.yaml.validator.output.junit.Testsuites;
+import org.alexmond.yaml.validator.output.sarif.ArtifactContent;
+import org.alexmond.yaml.validator.output.sarif.ArtifactLocation;
+import org.alexmond.yaml.validator.output.sarif.Invocation;
+import org.alexmond.yaml.validator.output.sarif.Location;
+import org.alexmond.yaml.validator.output.sarif.Message;
+import org.alexmond.yaml.validator.output.sarif.MultiformatMessageString;
+import org.alexmond.yaml.validator.output.sarif.PhysicalLocation;
+import org.alexmond.yaml.validator.output.sarif.Region;
+import org.alexmond.yaml.validator.output.sarif.ReportingConfiguration;
+import org.alexmond.yaml.validator.output.sarif.ReportingDescriptor;
+import org.alexmond.yaml.validator.output.sarif.Result;
+import org.alexmond.yaml.validator.output.sarif.Run;
+import org.alexmond.yaml.validator.output.sarif.SarifReport;
+import org.alexmond.yaml.validator.output.sarif.Tool;
+import org.alexmond.yaml.validator.output.sarif.ToolComponent;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
+
+/**
+ * GraalVM native image hints for reflection, resources, and serialization required by
+ * Jackson, NetworkNT json-schema-validator, and XML/Stax processing.
+ */
+@Configuration
+@ImportRuntimeHints(NativeImageHints.Registrar.class)
+class NativeImageHints {
+
+	static class Registrar implements RuntimeHintsRegistrar {
+
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			registerOutputModelClasses(hints);
+			registerConfigClasses(hints);
+			registerNetworkNtClasses(hints);
+			registerResources(hints);
+		}
+
+		private void registerOutputModelClasses(RuntimeHints hints) {
+			// SARIF model classes
+			Class<?>[] sarifClasses = { SarifReport.class, Run.class, Tool.class, ToolComponent.class, Result.class,
+					Message.class, Location.class, PhysicalLocation.class, ArtifactLocation.class, Region.class,
+					ArtifactContent.class, Invocation.class, ReportingDescriptor.class, ReportingConfiguration.class,
+					MultiformatMessageString.class };
+
+			// JUnit XML model classes
+			Class<?>[] junitClasses = { Testsuites.class, Testsuite.class, Testcase.class, Failure.class };
+
+			// Output wrapper classes
+			Class<?>[] outputClasses = { FilesOutput.class, FilesOutputToJunit.class, FilesOutputToSarif.class };
+
+			MemberCategory[] allAccess = { MemberCategory.DECLARED_FIELDS, MemberCategory.INVOKE_DECLARED_METHODS,
+					MemberCategory.INVOKE_DECLARED_CONSTRUCTORS };
+
+			for (Class<?> clazz : sarifClasses) {
+				hints.reflection().registerType(clazz, allAccess);
+			}
+			for (Class<?> clazz : junitClasses) {
+				hints.reflection().registerType(clazz, allAccess);
+			}
+			for (Class<?> clazz : outputClasses) {
+				hints.reflection().registerType(clazz, allAccess);
+			}
+		}
+
+		private void registerConfigClasses(RuntimeHints hints) {
+			MemberCategory[] allAccess = { MemberCategory.DECLARED_FIELDS, MemberCategory.INVOKE_DECLARED_METHODS,
+					MemberCategory.INVOKE_DECLARED_CONSTRUCTORS };
+
+			hints.reflection().registerType(YamlSchemaValidatorConfig.class, allAccess);
+			hints.reflection().registerType(ReportType.class, allAccess);
+		}
+
+		private void registerNetworkNtClasses(RuntimeHints hints) {
+			MemberCategory[] allAccess = { MemberCategory.DECLARED_FIELDS, MemberCategory.INVOKE_DECLARED_METHODS,
+					MemberCategory.INVOKE_DECLARED_CONSTRUCTORS };
+
+			// NetworkNT json-schema-validator core classes used reflectively
+			String[] networkNtClasses = { "com.networknt.schema.output.OutputUnit",
+					"com.networknt.schema.output.OutputFlag", "com.networknt.schema.SpecVersion",
+					"com.networknt.schema.SpecVersion$VersionFlag", "com.networknt.schema.JsonSchemaFactory",
+					"com.networknt.schema.JsonSchema", "com.networknt.schema.ValidationMessage",
+					"com.networknt.schema.SchemaValidatorsConfig",
+					"com.networknt.schema.SchemaValidatorsConfig$Builder" };
+
+			for (String className : networkNtClasses) {
+				try {
+					hints.reflection().registerType(Class.forName(className), allAccess);
+				}
+				catch (ClassNotFoundException ignored) {
+					// Skip if class not available
+				}
+			}
+		}
+
+		private void registerResources(RuntimeHints hints) {
+			// Stax/Woodstox XML SPI services (needed for JUnit XML output)
+			hints.resources().registerPattern("META-INF/services/javax.xml.stream.*");
+			hints.resources().registerPattern("META-INF/services/tools.jackson.*");
+
+			// NetworkNT schema dialect resources
+			hints.resources().registerPattern("draftv4/*");
+			hints.resources().registerPattern("draft2019-09/*");
+			hints.resources().registerPattern("draft2020-12/*");
+			hints.resources().registerPattern("draft7/*");
+			hints.resources().registerPattern("draft6/*");
+
+			// Spring Boot config
+			hints.resources().registerPattern("yj-schema-validator.yaml");
+			hints.resources().registerPattern("banner.txt");
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `native` profile to `pom.xml` with `native-maven-plugin` configuration (image name, `--no-fallback`)
- Add `NativeImageHints.java` — Spring AOT `RuntimeHintsRegistrar` for:
  - Reflection: all SARIF (15 classes), JUnit XML (4 classes), output, and config classes
  - Reflection: NetworkNT json-schema-validator core classes (SPI, validators, output)
  - Resources: Stax XML services, NetworkNT schema dialects, Spring Boot config
- Add `native-release.yml` GitHub Actions workflow:
  - Triggered on version tag push
  - Matrix build: Linux amd64/arm64, macOS Intel/Apple Silicon, Windows amd64
  - Uses GraalVM JDK 17, smoke tests each binary
  - Publishes executables to the existing GitHub Release

## Test plan
- [x] `./mvnw clean package` passes (standard build unaffected)
- [ ] Native build verified in CI on tag push (5 platform targets)
- [ ] Smoke test: `--help` and schema validation work on each platform

## Notes
- The native build workflow is additive — `maven_release.yml` is unchanged
- Additional reflection hints may be needed after real native testing (NetworkNT uses heavy reflection)
- GraalVM tracing agent can be used locally to discover additional hints if smoke tests fail

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)