### PR TITLE
ci: builder pipeline analogs

### DIFF
--- a/.builder/pipelines/check-jsonschema-test.yml
+++ b/.builder/pipelines/check-jsonschema-test.yml
@@ -1,0 +1,18 @@
+name: Validate JSON with check-jsonschema
+on: [push, manual]
+push:
+  branches: [main]
+jobs:
+  validate:
+    image: python:3.12
+    steps:
+      - name: Checkout
+        run: git clone --depth 1 https://github.com/alexmond/yj-schema-validator.git .
+      - name: Install check-jsonschema
+        run: pip install check-jsonschema
+      - name: Run validation and generate JSON report
+        run: |
+          check-jsonschema \
+            --schemafile src/test/resources/sample-schema.json \
+            src/test/resources/*json \
+            -o JSON > validation-report.json || true

--- a/.builder/pipelines/maven-release.yml
+++ b/.builder/pipelines/maven-release.yml
@@ -1,0 +1,29 @@
+name: Maven Release
+on: [manual]
+inputs:
+  releaseVersion:
+    type: string
+    description: Release version
+    required: true
+  nextVersion:
+    type: string
+    description: Next development version (with -SNAPSHOT suffix)
+    required: true
+jobs:
+  release:
+    image: eclipse-temurin:17-jdk
+    cache:
+      key: m2-yj-schema-validator
+      paths: [.m2/repository]
+    secrets: [OSSRH_USERNAME, OSSRH_PASSWORD, GPG_PRIVATE_KEY, GPG_PASSPHRASE]
+    steps:
+      - name: Checkout
+        run: git clone https://github.com/alexmond/yj-schema-validator.git .
+      - name: Prepare release version
+        run: ./mvnw versions:set -DnewVersion=$releaseVersion --no-transfer-progress -Dmaven.repo.local=.m2/repository
+      - name: Copy Maven settings.xml
+        run: |
+          mkdir -p ~/.m2
+          cp .github/settings.xml ~/.m2/settings.xml
+      - name: Deploy to Maven Central
+        run: ./mvnw --batch-mode -Dgpg.passphrase="$GPG_PASSPHRASE" clean deploy -Prelease --no-transfer-progress -Dmaven.repo.local=.m2/repository

--- a/.builder/pipelines/maven.yml
+++ b/.builder/pipelines/maven.yml
@@ -1,0 +1,15 @@
+name: Java CI with Maven
+on: [push, manual]
+push:
+  branches: [main]
+jobs:
+  build:
+    image: eclipse-temurin:17-jdk
+    cache:
+      key: m2-yj-schema-validator
+      paths: [.m2/repository]
+    steps:
+      - name: Checkout
+        run: git clone --depth 1 https://github.com/alexmond/yj-schema-validator.git .
+      - name: Build with Maven
+        run: ./mvnw -B package --file pom.xml -Pdefault --no-transfer-progress -Dmaven.repo.local=.m2/repository

--- a/.builder/pipelines/native-release.yml
+++ b/.builder/pipelines/native-release.yml
@@ -1,0 +1,30 @@
+name: Build Native Images
+on: [tag, manual]
+jobs:
+  build-jar:
+    image: eclipse-temurin:17-jdk
+    cache:
+      key: m2-yj-schema-validator
+      paths: [.m2/repository]
+    artifacts: [target/yj-schema-validator-*.jar]
+    steps:
+      - name: Checkout
+        run: git clone --depth 1 https://github.com/alexmond/yj-schema-validator.git .
+      - name: Build JAR
+        run: ./mvnw -B clean package -DskipTests --no-transfer-progress -Dmaven.repo.local=.m2/repository
+
+  build-native:
+    image: ghcr.io/graalvm/native-image-community:21
+    needs: [build-jar]
+    artifacts: [target/yj-schema-validator-linux-amd64]
+    steps:
+      - name: Checkout
+        run: git clone --depth 1 https://github.com/alexmond/yj-schema-validator.git .
+      - name: Build native image
+        run: ./mvnw -B -Pnative native:compile -DskipTests --no-transfer-progress
+      - name: Rename artifact
+        run: mv target/yj-schema-validator target/yj-schema-validator-linux-amd64
+      - name: Smoke test
+        run: |
+          ./target/yj-schema-validator-linux-amd64 --help
+          ./target/yj-schema-validator-linux-amd64 --schema=src/test/resources/testdata/sample-schema.json src/test/resources/testdata/valid.yaml


### PR DESCRIPTION
Adds `.builder/pipelines/*.yml` analogs of the four existing GitHub Actions workflows, so this repo can also be built by a builder (GitLab-style YAML) server. Purely additive and inert — nothing runs unless a builder server is pointed at the repo; the GitHub Actions workflows are untouched.

Mapped:
- `maven.yml` → CI build on push/manual (eclipse-temurin:17-jdk, `./mvnw package -Pdefault`, .m2 cache).
- `maven_release.yml` → manual release with `releaseVersion`/`nextVersion` inputs; OSSRH/GPG via secrets.
- `native-release.yml` → tag/manual; fat JAR job + GraalVM native-image job (`ghcr.io/graalvm/native-image-community:21`), JAR + native binary as artifacts.
- `check-jsonschema-test.yml` → push/manual jsonschema check on `python:3.12`.

Gaps (recorded, not blocking):
- Native cross-build is single-arch in builder — only the linux/amd64 lane is translated; the macOS/Windows/arm64 native artifacts have no analog.
- No git write-back, so the release pipeline does the version-set + deploy but cannot commit/tag/push or bump the next dev version.
- Dropped CI extras with no builder equivalent: codecov, jacoco-report, publish-unit-test-result, UniTrack reporting, dependency-submission, and the gh-release upload steps.