### PR TITLE
ci: publish GHCR image from the release job

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -57,6 +58,24 @@ jobs:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      # Publish the buildpacks image here (same job, POM still at the release version)
+      # rather than in a separate tag-triggered workflow: a tag pushed with GITHUB_TOKEN
+      # does not trigger other workflows, so a `push: tags` workflow would never fire.
+      - name: Publish image to GHCR (Spring Boot buildpacks)
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+          OWNER: ${{ github.repository_owner }}
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+        run: |
+          set -euo pipefail
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
+          ./mvnw -B spring-boot:build-image -DskipTests --no-transfer-progress
+          IMAGE="ghcr.io/${OWNER}/yj-schema-validator"
+          docker tag "${IMAGE}:${RELEASE_VERSION}" "${IMAGE}:latest"
+          docker push "${IMAGE}:${RELEASE_VERSION}"
+          docker push "${IMAGE}:latest"
 
       - name: Prepare for Next Development Version
         run: |

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -2,11 +2,12 @@ name: Publish Image
 
 # Builds the OCI image with Spring Boot Cloud Native Buildpacks (no Dockerfile) and
 # pushes it to GHCR, where the reusable GitHub Action (action.yml) pulls it from.
-# Runs on release tags; also dispatchable manually.
+#
+# Manual re-publish tool: dispatch it on a release tag (`gh workflow run
+# publish-image.yml --ref <tag>`). Releases publish the image inline from
+# maven_release.yml — a `push: tags` trigger here would never fire, since tags pushed
+# with GITHUB_TOKEN do not trigger workflows.
 on:
-  push:
-    tags:
-      - '[0-9]*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Fixes the image-publish gap found during the 3.0.0 release: `publish-image.yml`
(triggered on `push: tags`) never ran, because a tag pushed with `GITHUB_TOKEN`
does not trigger workflows. The 3.0.0 image had to be dispatched manually.

- **maven_release.yml** — build + push the buildpacks image to GHCR inline,
  right after the Central deploy (POM still at the release version). Added
  `packages: write`.
- **publish-image.yml** — kept as a manual re-publish tool (`workflow_dispatch`
  on a tag); dropped the never-firing `push: tags` trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)