### PR TITLE
Source SARIF tool version from build-info

### DIFF
--- a/src/main/java/org/alexmond/yaml/validator/YamlSchemaValidatorRunner.java
+++ b/src/main/java/org/alexmond/yaml/validator/YamlSchemaValidatorRunner.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.yaml.validator.config.YamlSchemaValidatorConfig;
 import org.alexmond.yaml.validator.output.FilesOutput;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
@@ -31,6 +33,13 @@ public class YamlSchemaValidatorRunner implements ApplicationRunner {
 	private final YamlSchemaValidator yamlSchemaValidator;
 
 	private final Environment environment;
+
+	/**
+	 * Build metadata (from the {@code build-info} Maven goal); optional so the runner
+	 * still works when constructed without a Spring context (e.g. in tests).
+	 */
+	@Autowired(required = false)
+	private BuildProperties buildProperties;
 
 	/**
 	 * Executes the validation process when the application starts. Handles command line
@@ -102,7 +111,7 @@ public class YamlSchemaValidatorRunner implements ApplicationRunner {
 			case JSON -> filesOutput.toJsonString();
 			case YAML -> filesOutput.toYamlString();
 			case JUNIT -> filesOutput.toJunitString();
-			case SARIF -> filesOutput.toSarifString();
+			case SARIF -> filesOutput.toSarifString(appVersion());
 			case LLM -> filesOutput.toLlmString(config.isCompact());
 			default -> filesOutput.toColoredString(config.isColor());
 		};
@@ -125,6 +134,15 @@ public class YamlSchemaValidatorRunner implements ApplicationRunner {
 	 * Displays usage instructions and available command line options. Exits the
 	 * application with status code 0 after printing the help message.
 	 */
+	/**
+	 * Resolves the tool version from the {@code build-info} metadata, falling back to
+	 * "unknown" when it is unavailable (e.g. no Spring context).
+	 * @return the application version
+	 */
+	private String appVersion() {
+		return (this.buildProperties != null) ? this.buildProperties.getVersion() : "unknown";
+	}
+
 	private void printHelp() {
 		String helpText = """
 				Usage: java -jar yaml-schema-validator.jar [options] [<file1> <file2> ...]

--- a/src/main/java/org/alexmond/yaml/validator/output/FilesOutput.java
+++ b/src/main/java/org/alexmond/yaml/validator/output/FilesOutput.java
@@ -162,6 +162,17 @@ public class FilesOutput {
 	}
 
 	/**
+	 * Converts the validation results to SARIF JSON format, tagging the tool driver with
+	 * the given version.
+	 * @param version the tool version to record in the SARIF driver (from build-info)
+	 * @return SARIF JSON string representation of the validation results
+	 */
+	public String toSarifString(String version) {
+		FilesOutputToSarif sarifOutput = new FilesOutputToSarif(files, version);
+		return sarifOutput.toSarifString();
+	}
+
+	/**
 	 * Converts the validation results to an LLM-friendly report.
 	 * @param compact true for compiler-style diagnostic lines, false for structured JSON
 	 * @return LLM-oriented string representation of the validation results

--- a/src/main/java/org/alexmond/yaml/validator/output/FilesOutputToSarif.java
+++ b/src/main/java/org/alexmond/yaml/validator/output/FilesOutputToSarif.java
@@ -1,7 +1,6 @@
 package org.alexmond.yaml.validator.output;
 
 import com.networknt.schema.output.OutputUnit;
-import lombok.RequiredArgsConstructor;
 import org.alexmond.yaml.validator.output.sarif.ArtifactContent;
 import org.alexmond.yaml.validator.output.sarif.ArtifactLocation;
 import org.alexmond.yaml.validator.output.sarif.Invocation;
@@ -31,10 +30,22 @@ import java.util.Map;
  * JSON structure that can be consumed by CI/CD tools, security scanners, and code
  * analysis systems.
  */
-@RequiredArgsConstructor
 public class FilesOutputToSarif {
 
+	private static final String UNKNOWN_VERSION = "unknown";
+
 	private final Map<String, OutputUnit> files;
+
+	private final String toolVersion;
+
+	public FilesOutputToSarif(Map<String, OutputUnit> files) {
+		this(files, UNKNOWN_VERSION);
+	}
+
+	public FilesOutputToSarif(Map<String, OutputUnit> files, String toolVersion) {
+		this.files = files;
+		this.toolVersion = toolVersion;
+	}
 
 	/**
 	 * Converts this FilesOutput to SARIF JSON format.
@@ -80,9 +91,9 @@ public class FilesOutputToSarif {
 	private Tool buildTool() {
 		ToolComponent driver = ToolComponent.builder()
 			.name("YAML Schema Validator")
-			.version("1.0.0")
+			.version(this.toolVersion)
 			.informationUri("https://github.com/alexmond/yj-schema-validator")
-			.semanticVersion("1.0.0")
+			.semanticVersion(this.toolVersion)
 			.rule(buildRule())
 			.build();
 

--- a/src/test/java/org/alexmond/yaml/validator/output/FilesOutputToSarifTest.java
+++ b/src/test/java/org/alexmond/yaml/validator/output/FilesOutputToSarifTest.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -50,6 +51,20 @@ class FilesOutputToSarifTest {
 		assertThat(run.get("results").isEmpty()).isTrue();
 		assertThat(run.get("invocations").get(0).get("executionSuccessful").asBoolean()).isTrue();
 		assertThat(run.get("invocations").get(0).get("exitCode").asInt()).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("toSarifString(version): driver version comes from build-info, not a hardcoded value")
+	void testToSarifString_driverVersionFromBuildInfo() throws IOException {
+		OutputUnit outputUnit = new OutputUnit();
+		outputUnit.setValid(true);
+		FilesOutput filesOutput = new FilesOutput(Map.of("file1.yaml", outputUnit));
+
+		String sarifString = filesOutput.toSarifString("9.9.9");
+
+		JsonNode driver = objectMapper.readTree(sarifString).get("runs").get(0).get("tool").get("driver");
+		assertEquals("9.9.9", driver.get("version").asText());
+		assertEquals("9.9.9", driver.get("semanticVersion").asText());
 	}
 
 	@Test
@@ -127,9 +142,11 @@ class FilesOutputToSarifTest {
 		JsonNode driver = sarifJson.get("runs").get(0).get("tool").get("driver");
 
 		assertThat(driver.get("name").asText()).isEqualTo("YAML Schema Validator");
-		assertThat(driver.get("version").asText()).isEqualTo("1.0.0");
+		// No-arg (no build-info context) falls back to "unknown"; the real version is
+		// supplied via toSarifString(version) from BuildProperties at runtime.
+		assertThat(driver.get("version").asText()).isEqualTo("unknown");
 		assertThat(driver.get("informationUri").asText()).isEqualTo("https://github.com/alexmond/yj-schema-validator");
-		assertThat(driver.get("semanticVersion").asText()).isEqualTo("1.0.0");
+		assertThat(driver.get("semanticVersion").asText()).isEqualTo("unknown");
 
 		JsonNode rules = driver.get("rules");
 		assertThat(rules.isArray()).isTrue();

--- a/src/test/resources/testreport/invalidyaml.sarif
+++ b/src/test/resources/testreport/invalidyaml.sarif
@@ -45,8 +45,8 @@
             "text" : "Schema validation error"
           }
         } ],
-        "semanticVersion" : "1.0.0",
-        "version" : "1.0.0"
+        "semanticVersion" : "unknown",
+        "version" : "unknown"
       }
     }
   } ],

--- a/src/test/resources/testreport/multi3invalidyaml.sarif
+++ b/src/test/resources/testreport/multi3invalidyaml.sarif
@@ -41,8 +41,8 @@
             "text" : "Schema validation error"
           }
         } ],
-        "semanticVersion" : "1.0.0",
-        "version" : "1.0.0"
+        "semanticVersion" : "unknown",
+        "version" : "unknown"
       }
     }
   } ],

--- a/src/test/resources/testreport/test1sarif.sarif
+++ b/src/test/resources/testreport/test1sarif.sarif
@@ -5,9 +5,9 @@
     "tool" : {
       "driver" : {
         "name" : "YAML Schema Validator",
-        "version" : "1.0.0",
+        "version" : "unknown",
         "informationUri" : "https://github.com/alexmond/yj-schema-validator",
-        "semanticVersion" : "1.0.0",
+        "semanticVersion" : "unknown",
         "rules" : [ {
           "id" : "schema-validation",
           "shortDescription" : {

--- a/src/test/resources/testreport/validyaml.sarif
+++ b/src/test/resources/testreport/validyaml.sarif
@@ -27,8 +27,8 @@
             "text" : "Schema validation error"
           }
         } ],
-        "semanticVersion" : "1.0.0",
-        "version" : "1.0.0"
+        "semanticVersion" : "unknown",
+        "version" : "unknown"
       }
     }
   } ],


### PR DESCRIPTION
The SARIF report's tool driver version was hardcoded `1.0.0`. Now it comes from Spring Boot's `BuildProperties` (the `build-info` Maven goal is already configured), so the SARIF driver reports the real release version.

- `FilesOutputToSarif` — new `(files, version)` constructor; version used for `driver.version` + `semanticVersion` (was hardcoded).
- `FilesOutput.toSarifString(version)` overload; `YamlSchemaValidatorRunner` injects `BuildProperties` (optional) and passes it.
- Fallback `"unknown"` when no build-info context (unit tests) — stable, doesn't churn per release. Updated SARIF fixtures + assertions accordingly.

Verified end-to-end: `--report-type=SARIF` from the packaged jar now reports `driver.version = 3.0.1-SNAPSHOT`. Build green, 92 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)